### PR TITLE
Fix typo in Host Game screen

### DIFF
--- a/MoonbaseConsole/MoonbaseConsole.rc
+++ b/MoonbaseConsole/MoonbaseConsole.rc
@@ -134,7 +134,7 @@ BEGIN
     LTEXT           "IP &Address:",IDC_STATIC,68,38,40,10
     LTEXT           "To host a game, enter your IP address in the box below and press the Host button. If you do not know your IP address, try one of the options below.",
                     IDC_STATIC,5,5,225,25
-    LTEXT           "If you are playing a game over the internet, pick a detection site from the list below and press the Detect Internet Address button. Note that you will need to forward ports 2300 TCP, 2350 UDP and 74624 TCP to your computer for this to work.",
+    LTEXT           "If you are playing a game over the internet, pick a detection site from the list below and press the Detect Internet Address button. Note that you will need to forward ports 2300 TCP, 2350 UDP and 47624 TCP to your computer for this to work.",
                     IDC_STATIC,5,65,225,35
     LTEXT           "If you are playing a game over a network, press the Detect LAN Address button.",
                     IDC_STATIC,5,120,225,15


### PR DESCRIPTION
It looked like there was a typo in the list of ports to forward on the Host screen. Should fix #3.